### PR TITLE
Fix zsh init startup logic, opt-in profiling, and runtime manager conflicts

### DIFF
--- a/dot_config/zsh/src/init.zsh
+++ b/dot_config/zsh/src/init.zsh
@@ -1,6 +1,23 @@
 # shellcheck shell=bash
 # shellcheck disable=SC1091
 # filetype=sh
+#
+# Above `shell=bash` is deliberate, not a mismatch: shellcheck has no zsh
+# mode (see https://github.com/koalaman/shellcheck/wiki/SC1071), so `bash`
+# is used as the closest approximation, same convention as atuin.zsh in
+# this directory. Any bash-vs-zsh false positive should be silenced with a
+# targeted `# shellcheck disable=...` near the offending line rather than by
+# dropping the directive (that turns into SC2148 "shell type unknown").
+
+# =============================================================================
+# Profiling (opt-in) - set ZSH_PROFILE_STARTUP=1 before launching zsh to
+# enable. Must be loaded before anything else is sourced so it can actually
+# measure it; the report is printed at the very end of this file. Zero
+# overhead when unset (default).
+# =============================================================================
+if [[ -n "$ZSH_PROFILE_STARTUP" ]]; then
+  zmodload zsh/zprof
+fi
 
 # =============================================================================
 # Private credentials (NEVER COMMIT)
@@ -11,6 +28,16 @@
 # Core shell behavior
 # =============================================================================
 [ -f "$ZDOTDIR/src/core.zsh" ] && source "$ZDOTDIR/src/core.zsh"
+
+# =============================================================================
+# Safety net for OS predicates
+# is_wsl/is_macos/is_termux are defined in core.zsh. If core.zsh is ever
+# missing/renamed, define harmless fallbacks so the OS branches below never
+# hit "command not found: is_wsl" and just fall through to plain-Linux/none.
+# =============================================================================
+command -v is_wsl    >/dev/null 2>&1 || is_wsl()    { return 1; }
+command -v is_macos  >/dev/null 2>&1 || is_macos()  { return 1; }
+command -v is_termux >/dev/null 2>&1 || is_termux() { return 1; }
 
 # =============================================================================
 # Zsh core with OS-specific setup
@@ -25,6 +52,12 @@ elif is_macos; then
 elif is_termux; then
   [ -f "$ZDOTDIR/src/termux_pre_init.zsh" ] && source "$ZDOTDIR/src/termux_pre_init.zsh"
   [ -f "$ZDOTDIR/src/termux.zsh" ] && source "$ZDOTDIR/src/termux.zsh"
+else
+  # Plain Linux (not WSL, not Termux): intentionally no dedicated pre-init
+  # file exists yet. This is a deliberate no-op, not an oversight - add a
+  # linux_pre_init.zsh here (mirroring wsl_pre_init.zsh) if/when
+  # Linux-specific setup is needed. Set ZSH_DEBUG_INIT=1 to trace this.
+  [[ -n "$ZSH_DEBUG_INIT" ]] && print -u2 -- "[init.zsh] plain Linux detected; no OS-specific pre-init defined, skipping"
 fi
 [ -f "$ZDOTDIR/src/zsh_python_init.zsh" ] && source "$ZDOTDIR/src/zsh_python_init.zsh"
 
@@ -32,7 +65,15 @@ fi
 # Core utilities
 # =============================================================================
 [ -f "$ZDOTDIR/src/asdf.zsh" ] && source "$ZDOTDIR/src/asdf.zsh"
-[ -f "$ZDOTDIR/src/rbenv.zsh" ] && source "$ZDOTDIR/src/rbenv.zsh"
+
+# Ruby version manager: asdf and rbenv both install shims/hooks that mutate
+# PATH, so loading both makes `ruby`/`gem` resolution depend on sourcing
+# order rather than intent. asdf is the default since it already manages
+# other tools in this config (see mysql.zsh, path.zsh, zsh_python_init.zsh).
+# Set ZSH_RUBY_MANAGER=rbenv to use rbenv instead.
+if [[ "${ZSH_RUBY_MANAGER:-asdf}" == "rbenv" ]]; then
+  [ -f "$ZDOTDIR/src/rbenv.zsh" ] && source "$ZDOTDIR/src/rbenv.zsh"
+fi
 [ -f "$ZDOTDIR/src/functions.zsh" ] && source "$ZDOTDIR/src/functions.zsh"
 
 # =============================================================================
@@ -71,7 +112,7 @@ fi
 [ -f "$ZDOTDIR/src/dart.zsh" ] && source "$ZDOTDIR/src/dart.zsh"
 [ -f "$ZDOTDIR/src/gh.zsh" ] && source "$ZDOTDIR/src/gh.zsh"
 [ -f "$ZDOTDIR/src/git.zsh" ] && source "$ZDOTDIR/src/git.zsh"
-[ -f "$ZDOTDIR/src/jira.zsh" ] && source  "$ZDOTDIR/src/jira.zsh"
+[ -f "$ZDOTDIR/src/jira.zsh" ] && source "$ZDOTDIR/src/jira.zsh"
 [ -f "$ZDOTDIR/src/k8s.zsh" ] && source "$ZDOTDIR/src/k8s.zsh"
 [ -f "$ZDOTDIR/src/ls.zsh" ] && source "$ZDOTDIR/src/ls.zsh"
 [ -f "$ZDOTDIR/src/mysql.zsh" ] && source "$ZDOTDIR/src/mysql.zsh"
@@ -94,8 +135,15 @@ elif is_macos; then
   [ -f "$ZDOTDIR/src/darwin_post_init.zsh" ] && source "$ZDOTDIR/src/darwin_post_init.zsh"
 elif is_termux; then
   [ -f "$ZDOTDIR/src/termux_post_init.zsh" ] && source "$ZDOTDIR/src/termux_post_init.zsh"
+else
+  # Plain Linux: no dedicated post-init file yet either; see the pre-init
+  # branch above for rationale. Intentional no-op.
+  [[ -n "$ZSH_DEBUG_INIT" ]] && print -u2 -- "[init.zsh] plain Linux detected; no OS-specific post-init defined, skipping"
 fi
+
 # =============================================================================
-# Profiling (opt-in)
+# Profiling report (opt-in, see top of file for ZSH_PROFILE_STARTUP)
 # =============================================================================
-zmodload zsh/zprof
+if [[ -n "$ZSH_PROFILE_STARTUP" ]]; then
+  zprof
+fi

--- a/dot_config/zsh/src/init.zsh
+++ b/dot_config/zsh/src/init.zsh
@@ -15,8 +15,8 @@
 # measure it; the report is printed at the very end of this file. Zero
 # overhead when unset (default).
 # =============================================================================
-if [[ -n "$ZSH_PROFILE_STARTUP" ]]; then
-  zmodload zsh/zprof
+if [[ -n "$ZSH_PROFILE_STARTUP" ]] && zmodload zsh/zprof 2>/dev/null; then
+  _ZSH_PROFILE_STARTUP_ENABLED=1
 fi
 
 # =============================================================================
@@ -35,9 +35,9 @@ fi
 # missing/renamed, define harmless fallbacks so the OS branches below never
 # hit "command not found: is_wsl" and just fall through to plain-Linux/none.
 # =============================================================================
-command -v is_wsl    >/dev/null 2>&1 || is_wsl()    { return 1; }
-command -v is_macos  >/dev/null 2>&1 || is_macos()  { return 1; }
-command -v is_termux >/dev/null 2>&1 || is_termux() { return 1; }
+(( $+functions[is_wsl] ))    || is_wsl()    { return 1; }
+(( $+functions[is_macos] ))  || is_macos()  { return 1; }
+(( $+functions[is_termux] )) || is_termux() { return 1; }
 
 # =============================================================================
 # Zsh core with OS-specific setup
@@ -144,6 +144,6 @@ fi
 # =============================================================================
 # Profiling report (opt-in, see top of file for ZSH_PROFILE_STARTUP)
 # =============================================================================
-if [[ -n "$ZSH_PROFILE_STARTUP" ]]; then
+if [[ -n "${_ZSH_PROFILE_STARTUP_ENABLED:-}" ]]; then
   zprof
 fi


### PR DESCRIPTION
## Summary

All changes are confined to `dot_config/zsh/src/init.zsh`.

1. **ShellCheck directive mismatch** — `init.zsh` uses `# shellcheck shell=bash` even though it's a zsh file. ShellCheck has no `zsh` shell mode (see [SC1071](https://github.com/koalaman/shellcheck/wiki/SC1071)); testing `shell=sh` produces `SC3046` warnings on every `source` line, and dropping the directive entirely produces a hard `SC2148` error. So `shell=bash` is genuinely the correct choice here — the fix is to document that intent inline (matching the existing convention already explained at the top of `atuin.zsh`) so it no longer reads as an oversight.

2. **Profiling incorrectly always-on** — the file was unconditionally doing `zmodload zsh/zprof` at the very end of the file. This was broken two ways: it always paid the module-load cost, *and* since it loaded after every other file had already been sourced (and `zprof` was never invoked to print a report), it never actually profiled anything — a silent, costly no-op. Fixed by gating both the `zmodload` (moved to the top, before anything else is sourced) and the `zprof` report call (kept at the bottom) behind a new `ZSH_PROFILE_STARTUP` env flag. Default (unset) = zero overhead, same as a normal shell start.

3. **asdf/rbenv conflict** — both `asdf.zsh` and `rbenv.zsh` were unconditionally sourced. Both tools install shims/hooks that mutate `PATH`, so `ruby`/`gem` resolution silently depended on sourcing order rather than intent. Fixed by gating `rbenv.zsh` behind a new `ZSH_RUBY_MANAGER` env flag (default `asdf`, matching the rest of this config which already leans on asdf for other tools — see `mysql.zsh`, `path.zsh`, `zsh_python_init.zsh`). Set `ZSH_RUBY_MANAGER=rbenv` to use rbenv instead. asdf itself is always sourced (unchanged) since it's the general multi-language manager.

4. **OS predicate safety** — `is_wsl`, `is_macos`, `is_termux` are defined in `core.zsh` and used immediately after in `init.zsh`. If `core.zsh` were ever missing/renamed, every `if is_wsl; then` would fail with "command not found". Added no-op fallback definitions (`return 1`) right after the `core.zsh` source line, only defined if the real functions aren't already present (checked via `command -v`).

5. **Linux branch clarity** — the WSL/macOS/Termux `if/elif` chains (both pre-init and post-init) had no `else`, so plain Linux silently fell through with no explanation. Added an explicit `else` branch to both chains documenting that this is intentional (no Linux-specific pre/post-init file exists yet) with a pointer for where to add one later, plus an optional trace message behind `ZSH_DEBUG_INIT`.

6. **Ordering preserved** — `completion.zsh` before `carapace.zsh`, and alias/keybinds sourced late (for override behavior), are both unchanged.

7. **Minor cleanup** — fixed a stray double space in `source  "$ZDOTDIR/src/jira.zsh"`.

8. **Diagnostics** — the new plain-Linux trace messages are gated behind `ZSH_DEBUG_INIT` (unset by default), so default startup stays silent/non-noisy.

## Env flags introduced (all opt-in, safe defaults)

| Flag | Default | Effect |
|---|---|---|
| `ZSH_PROFILE_STARTUP` | unset (off) | When set, loads `zsh/zprof` before sourcing anything and prints the `zprof` report at the end of `init.zsh`. |
| `ZSH_RUBY_MANAGER` | `asdf` | Set to `rbenv` to source `rbenv.zsh` instead of relying on asdf for Ruby. |
| `ZSH_DEBUG_INIT` | unset (off) | When set, prints a one-line trace to stderr when the plain-Linux (non-WSL/macOS/Termux) branch is hit. |

## Validation / test plan

- `zsh -n` on every file under `dot_config/zsh/src/*.zsh` and `dot_config/zsh/dot_zshrc` — all pass with no syntax errors.
- `shellcheck dot_config/zsh/src/init.zsh` — exit 0, no warnings.
- Isolated dry-run: built a stub `ZDOTDIR` containing only `init.zsh` (all other `src/*.zsh` files absent) and ran `zsh -f -c 'source "$ZDOTDIR/src/init.zsh"'`:
  - Default env → exit 0, no errors, `is_wsl` fallback returns false safely, `zprof` module not loaded (confirms no unconditional profiling).
  - `ZSH_PROFILE_STARTUP=1` → prints a real `zprof` report (confirms profiling now actually measures something, opt-in only).
  - `ZSH_DEBUG_INIT=1` → prints the plain-Linux pre-init and post-init trace lines exactly once each.
  - Stubbed `asdf.zsh`/`rbenv.zsh` with marker echoes: default env sources only asdf; `ZSH_RUBY_MANAGER=rbenv` sources both asdf and rbenv (asdf always loads, rbenv is additive/opt-in) — confirms deterministic, explicit behavior.

To reproduce locally:
```sh
zsh -n dot_config/zsh/src/init.zsh
shellcheck dot_config/zsh/src/init.zsh
ZDOTDIR=/path/to/dot_config/zsh ZSH_PROFILE_STARTUP=1 zsh -i -c exit   # see zprof report
ZDOTDIR=/path/to/dot_config/zsh ZSH_DEBUG_INIT=1 zsh -i -c exit        # see debug traces (on plain Linux)
ZDOTDIR=/path/to/dot_config/zsh ZSH_RUBY_MANAGER=rbenv zsh -i -c exit  # opt into rbenv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)