### PR TITLE
Fix high/medium severity zsh startup bugs

### DIFF
--- a/dot_config/zsh/src/alias.zsh
+++ b/dot_config/zsh/src/alias.zsh
@@ -7,8 +7,8 @@ alias lg='lazygit'
 alias zshrc_edit='vim "$ZDOTDIR/.zshrc"'
 alias zshrc_reload='source "$ZDOTDIR/.zshrc"'
 
-alias nlof="$HOME/myscripts/fzf-listoldfiles"
-alias nzo="$HOME/myscripts/zoxide-openfiles-nvim"
+alias nlof="$ZDOTDIR/src/myscripts/fzf-listoldfiles"
+alias nzo="$ZDOTDIR/src/myscripts/zoxide-openfiles-nvim"
 alias gr='cd "$(git rev-parse --show-toplevel 2>/dev/null)"'
 
 

--- a/dot_config/zsh/src/alias.zsh
+++ b/dot_config/zsh/src/alias.zsh
@@ -4,8 +4,8 @@ alias tree='eza --tree'
 alias vim='nvim'
 alias cls='clear'
 alias lg='lazygit'
-alias zshrc_edit='vim $HOME/.zsh'
-alias zshrc_reload='source $HOME/.zshrc'
+alias zshrc_edit='vim "$ZDOTDIR/.zshrc"'
+alias zshrc_reload='source "$ZDOTDIR/.zshrc"'
 
 alias nlof="$HOME/myscripts/fzf-listoldfiles"
 alias nzo="$HOME/myscripts/zoxide-openfiles-nvim"

--- a/dot_config/zsh/src/atuin.zsh
+++ b/dot_config/zsh/src/atuin.zsh
@@ -7,6 +7,13 @@
 # the above line ...
 
 # Source this in your ~/.zshrc
+
+# Guard: everything below shells out to `atuin` on every prompt/command, so
+# without this the whole file breaks noisily on any machine without atuin.
+if ! command -v atuin >/dev/null 2>&1; then
+  return
+fi
+
 autoload -U add-zsh-hook
 
 zmodload zsh/datetime 2>/dev/null

--- a/dot_config/zsh/src/aws.zsh
+++ b/dot_config/zsh/src/aws.zsh
@@ -17,8 +17,8 @@ function aws_login() {
     echo "Usage: aws_login <profile>" >&2
     return 2
   fi
-  if ! command -v aws-azure-login >/dev/null 2>&1; then
-    echo "aws-azure-login not found" >&2
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "aws not found" >&2
     return 127
   fi
   aws --profile "$profile" login

--- a/dot_config/zsh/src/core.zsh
+++ b/dot_config/zsh/src/core.zsh
@@ -7,6 +7,11 @@ setopt hist_save_no_dups
 setopt hist_ignore_dups
 setopt hist_find_no_dups
 
+# Must run before anything that does `bindkey -M viins/vicmd ...` (atuin.zsh,
+# pet.zsh, etc.) - `bindkey -v` reinitializes the vi keymaps and silently
+# wipes out custom bindings set on them beforehand.
+bindkey -v
+
 export PATH="$XDG_DATA_HOME/npm/bin:$PATH"
 
 # =============================================================================

--- a/dot_config/zsh/src/darwin_post_init.zsh
+++ b/dot_config/zsh/src/darwin_post_init.zsh
@@ -6,5 +6,6 @@ alias firefox_version='/Applications/Firefox.app/Contents/MacOS/firefox --versio
 alias chrome='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'
 alias chrome_version='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version'
 
-
-export PATH="$HOME/.asdf/shims:$PATH"
+# asdf.zsh (sourced earlier via asdf.sh) already manages the shims dir.
+# Re-prepending it here unconditionally would override an explicit
+# ZSH_RUBY_MANAGER=rbenv choice made earlier in init.zsh, so it's removed.

--- a/dot_config/zsh/src/darwin_pre_init.zsh
+++ b/dot_config/zsh/src/darwin_pre_init.zsh
@@ -2,9 +2,11 @@
 # shellcheck shell=bash
 export HOMEBREW_HOME="/opt/homebrew"
 
-export SYS_PYTHON_ROOT="$(brew --prefix python@3.12)"
-export SYS_PYTHON_BIN="$SYS_PYTHON_ROOT/bin/python3.12"
-export SYS_PIP_BIN="$SYS_PYTHON_ROOT/bin/pip3.12"
+if command -v brew >/dev/null 2>&1; then
+  export SYS_PYTHON_ROOT="$(brew --prefix python@3.12 2>/dev/null)"
+  export SYS_PYTHON_BIN="$SYS_PYTHON_ROOT/bin/python3.12"
+  export SYS_PIP_BIN="$SYS_PYTHON_ROOT/bin/pip3.12"
 
-alias sys_python='$SYS_PYTHON_BIN'
-alias sys_pip='$SYS_PIP_BIN'
+  alias sys_python='$SYS_PYTHON_BIN'
+  alias sys_pip='$SYS_PIP_BIN'
+fi

--- a/dot_config/zsh/src/darwin_pre_init.zsh
+++ b/dot_config/zsh/src/darwin_pre_init.zsh
@@ -3,10 +3,17 @@
 export HOMEBREW_HOME="/opt/homebrew"
 
 if command -v brew >/dev/null 2>&1; then
-  export SYS_PYTHON_ROOT="$(brew --prefix python@3.12 2>/dev/null)"
-  export SYS_PYTHON_BIN="$SYS_PYTHON_ROOT/bin/python3.12"
-  export SYS_PIP_BIN="$SYS_PYTHON_ROOT/bin/pip3.12"
+  _sys_python_root="$(brew --prefix python@3.12 2>/dev/null)"
 
-  alias sys_python='$SYS_PYTHON_BIN'
-  alias sys_pip='$SYS_PIP_BIN'
+  # brew --prefix prints nothing if the formula isn't installed - only wire
+  # up the exports/aliases when the interpreter actually resolved.
+  if [[ -n "$_sys_python_root" && -x "$_sys_python_root/bin/python3.12" ]]; then
+    export SYS_PYTHON_ROOT="$_sys_python_root"
+    export SYS_PYTHON_BIN="$SYS_PYTHON_ROOT/bin/python3.12"
+    export SYS_PIP_BIN="$SYS_PYTHON_ROOT/bin/pip3.12"
+
+    alias sys_python='$SYS_PYTHON_BIN'
+    alias sys_pip='$SYS_PIP_BIN'
+  fi
+  unset _sys_python_root
 fi

--- a/dot_config/zsh/src/executable_sleep.zsh
+++ b/dot_config/zsh/src/executable_sleep.zsh
@@ -1,8 +1,9 @@
 #!/usr/bin/env zsh
 
-echo "$(date) sleepwatcher triggered ($0)" >> "/tmp/sleepwatcher.log"
-source "$HOME/.zsh/darwin_pre_init.zsh"
-export PYTHONPATH="$HOME/.zsh"
+mkdir -p "$XDG_CACHE_HOME"
+echo "$(date) sleepwatcher triggered ($0)" >> "$XDG_CACHE_HOME/sleepwatcher.log"
+source "$ZDOTDIR/src/darwin_pre_init.zsh"
+export PYTHONPATH="$ZDOTDIR/src"
 
 # Get the day of the week (0 = Sunday, 6 = Saturday)
 day_of_week=$(date +%w)

--- a/dot_config/zsh/src/executable_sleep.zsh
+++ b/dot_config/zsh/src/executable_sleep.zsh
@@ -1,5 +1,8 @@
 #!/usr/bin/env zsh
 
+# Launchd's environment can be sparser than a login shell's - don't assume
+# XDG_CACHE_HOME made it through.
+: "${XDG_CACHE_HOME:=$HOME/.cache}"
 mkdir -p "$XDG_CACHE_HOME"
 echo "$(date) sleepwatcher triggered ($0)" >> "$XDG_CACHE_HOME/sleepwatcher.log"
 source "$ZDOTDIR/src/darwin_pre_init.zsh"
@@ -11,6 +14,14 @@ day_of_week=$(date +%w)
 # Skip weekends
 if [[ "$day_of_week" -eq 0 || "$day_of_week" -eq 6 ]]; then
   exit 0
+fi
+
+# darwin_pre_init.zsh only exports SYS_PYTHON_BIN when brew/python@3.12
+# actually resolved - without this check, running "" as a command fails
+# with no useful trace and we'd silently skip everything below.
+if [[ -z "$SYS_PYTHON_BIN" || ! -x "$SYS_PYTHON_BIN" ]]; then
+  echo "$(date) sleepwatcher: SYS_PYTHON_BIN unset/not executable, skipping should_run check" >> "$XDG_CACHE_HOME/sleepwatcher.log"
+  exit 1
 fi
 
 # Skip if disabled in DB

--- a/dot_config/zsh/src/executable_sleep.zsh
+++ b/dot_config/zsh/src/executable_sleep.zsh
@@ -3,7 +3,7 @@
 mkdir -p "$XDG_CACHE_HOME"
 echo "$(date) sleepwatcher triggered ($0)" >> "$XDG_CACHE_HOME/sleepwatcher.log"
 source "$ZDOTDIR/src/darwin_pre_init.zsh"
-export PYTHONPATH="$ZDOTDIR/src"
+export PYTHONPATH="$ZDOTDIR/src/python"
 
 # Get the day of the week (0 = Sunday, 6 = Saturday)
 day_of_week=$(date +%w)
@@ -14,7 +14,7 @@ if [[ "$day_of_week" -eq 0 || "$day_of_week" -eq 6 ]]; then
 fi
 
 # Skip if disabled in DB
-if ! "$SYS_PYTHON_BIN" -m python.sleepwatcher.should_run sleep; then
+if ! "$SYS_PYTHON_BIN" -m sleepwatcher.should_run sleep; then
   exit 0
 fi
 

--- a/dot_config/zsh/src/executable_wakeup.zsh
+++ b/dot_config/zsh/src/executable_wakeup.zsh
@@ -1,8 +1,9 @@
 #!/usr/bin/env zsh
 
-echo "$(date) sleepwatcher triggered ($0)" >> "/tmp/sleepwatcher.log"
-source "$HOME/.zsh/darwin_pre_init.zsh"
-export PYTHONPATH="$HOME/.zsh"
+mkdir -p "$XDG_CACHE_HOME"
+echo "$(date) sleepwatcher triggered ($0)" >> "$XDG_CACHE_HOME/sleepwatcher.log"
+source "$ZDOTDIR/src/darwin_pre_init.zsh"
+export PYTHONPATH="$ZDOTDIR/src"
 
 # Get the day of the week (0 = Sunday, 6 = Saturday)
 day_of_week=$(date +%w)

--- a/dot_config/zsh/src/executable_wakeup.zsh
+++ b/dot_config/zsh/src/executable_wakeup.zsh
@@ -1,5 +1,8 @@
 #!/usr/bin/env zsh
 
+# Launchd's environment can be sparser than a login shell's - don't assume
+# XDG_CACHE_HOME made it through.
+: "${XDG_CACHE_HOME:=$HOME/.cache}"
 mkdir -p "$XDG_CACHE_HOME"
 echo "$(date) sleepwatcher triggered ($0)" >> "$XDG_CACHE_HOME/sleepwatcher.log"
 source "$ZDOTDIR/src/darwin_pre_init.zsh"
@@ -11,6 +14,14 @@ day_of_week=$(date +%w)
 # Skip weekends
 if [[ "$day_of_week" -eq 0 || "$day_of_week" -eq 6 ]]; then
   exit 0
+fi
+
+# darwin_pre_init.zsh only exports SYS_PYTHON_BIN when brew/python@3.12
+# actually resolved - without this check, running "" as a command fails
+# with no useful trace and we'd silently skip everything below.
+if [[ -z "$SYS_PYTHON_BIN" || ! -x "$SYS_PYTHON_BIN" ]]; then
+  echo "$(date) sleepwatcher: SYS_PYTHON_BIN unset/not executable, skipping should_run check" >> "$XDG_CACHE_HOME/sleepwatcher.log"
+  exit 1
 fi
 
 # Skip if disabled in DB

--- a/dot_config/zsh/src/executable_wakeup.zsh
+++ b/dot_config/zsh/src/executable_wakeup.zsh
@@ -3,7 +3,7 @@
 mkdir -p "$XDG_CACHE_HOME"
 echo "$(date) sleepwatcher triggered ($0)" >> "$XDG_CACHE_HOME/sleepwatcher.log"
 source "$ZDOTDIR/src/darwin_pre_init.zsh"
-export PYTHONPATH="$ZDOTDIR/src"
+export PYTHONPATH="$ZDOTDIR/src/python"
 
 # Get the day of the week (0 = Sunday, 6 = Saturday)
 day_of_week=$(date +%w)
@@ -14,7 +14,7 @@ if [[ "$day_of_week" -eq 0 || "$day_of_week" -eq 6 ]]; then
 fi
 
 # Skip if disabled in DB
-if ! "$SYS_PYTHON_BIN" -m python.sleepwatcher.should_run wake; then
+if ! "$SYS_PYTHON_BIN" -m sleepwatcher.should_run wake; then
   exit 0
 fi
 

--- a/dot_config/zsh/src/functions.zsh
+++ b/dot_config/zsh/src/functions.zsh
@@ -24,7 +24,7 @@ function mkcd() {
 }
 
 function pbpaste_dump() {
-  local filename="dump_pbpaste_$(date +%s%N | sha256sum | head -c 8).txt"
+  local filename="dump_pbpaste_$(date +%s%N | shasum -a 256 | head -c 8).txt"
   pbpaste | nl -s" | " -w3 -nln > "$filename"
   echo "Saved clipboard to $filename"
 }
@@ -35,6 +35,11 @@ function send_notification() {
   subtitle="$3"
   sound="$4"
   open_url="$5"
+
+  if ! command -v terminal-notifier >/dev/null 2>&1; then
+    echo "send_notification: terminal-notifier not found (brew install terminal-notifier)" >&2
+    return 127
+  fi
 
   if [[ -n "$sound" ]]; then
     terminal-notifier \

--- a/dot_config/zsh/src/functions.zsh
+++ b/dot_config/zsh/src/functions.zsh
@@ -24,7 +24,7 @@ function mkcd() {
 }
 
 function pbpaste_dump() {
-  local filename="dump_pbpaste_$(date +%s%N | shasum -a 256 | head -c 8).txt"
+  local filename="dump_pbpaste_$(head -c 16 /dev/urandom | shasum -a 256 | head -c 8).txt"
   pbpaste | nl -s" | " -w3 -nln > "$filename"
   echo "Saved clipboard to $filename"
 }

--- a/dot_config/zsh/src/fzf.zsh
+++ b/dot_config/zsh/src/fzf.zsh
@@ -21,7 +21,3 @@ export FZF_DEFAULT_OPTS='
     fi
   "
 '
-
-# Keybindings
-source /usr/share/fzf/key-bindings.zsh 2>/dev/null || true
-source /usr/share/fzf/completion.zsh   2>/dev/null || true

--- a/dot_config/zsh/src/gh.zsh
+++ b/dot_config/zsh/src/gh.zsh
@@ -50,11 +50,6 @@ function ghpr_view() {
   rest="$(__gh_parse_pbcopy_flag "$@")"
   rc=$?
 
-  if (( rc == 2 )); then
-    echo "Usage: ghpr_view [--pbcopy] [PR_NUMBER]" >&2
-    return 2
-  fi
-
   pr="$rest"
 
   if (( rc == 10 )); then
@@ -75,11 +70,6 @@ function ghpr_url() {
   rest="$(__gh_parse_pbcopy_flag "$@")"
   rc=$?
 
-  if (( rc == 2 )); then
-    echo "Usage: ghpr_copy [--pbcopy] [PR_NUMBER]" >&2
-    return 2
-  fi
-
   pr="$rest"
 
   if [[ -n "$pr" ]]; then
@@ -97,11 +87,6 @@ function ghpr_watch() {
 
   rest="$(__gh_parse_pbcopy_flag "$@")"
   rc=$?
-
-  if (( rc == 2 )); then
-    echo "Usage: ghpr_watch [--pbcopy] [PR_NUMBER]" >&2
-    return 2
-  fi
 
   pr="$rest"
 
@@ -169,11 +154,6 @@ function ghpr_fzf_open() {
   # parse --pbcopy (shared helper)
   rest="$(__gh_parse_pbcopy_flag "$@")"
   rc=$?
-
-  if (( rc == 2 )); then
-    echo "Usage: ghpr_fzf_open [--pbcopy] [gh pr list options]" >&2
-    return 2
-  fi
 
   pr="$(
     gh pr list ${=rest} --limit 500 \

--- a/dot_config/zsh/src/keybinds.zsh
+++ b/dot_config/zsh/src/keybinds.zsh
@@ -1,5 +1,6 @@
 # ==== Bindkey =================================================================
-bindkey -v
+# `bindkey -v` now lives in core.zsh (must run before atuin.zsh/pet.zsh
+# install their custom viins/vicmd bindings).
 bindkey '\e[3~' delete-char
 bindkey '^p' history-search-backward
 bindkey '^n' history-search-forward

--- a/dot_config/zsh/src/notify.zsh
+++ b/dot_config/zsh/src/notify.zsh
@@ -10,6 +10,11 @@ _notify_macos() {
   local sound="$4"
   local open_url="$5"
 
+  if ! command -v terminal-notifier >/dev/null 2>&1; then
+    echo "notify: terminal-notifier not found (brew install terminal-notifier)" >&2
+    return 127
+  fi
+
   command terminal-notifier \
     -message "$msg" \
     -title "$title" \

--- a/dot_config/zsh/src/path.zsh
+++ b/dot_config/zsh/src/path.zsh
@@ -5,10 +5,12 @@ add_path_back()  { [[ -d "$1" ]] && path+=("$1") }
 
 add_path_front "$HOME/.local/bin"
 
-export BUN_INSTALL="$HOME/Library/Application Support/reflex/bun"
+# BUN_INSTALL is already set correctly (XDG-based) in ~/.zshenv.
 add_path_front "$BUN_INSTALL/bin"
 
-add_path_front "$HOME/.rbenv/bin"
+# Only put rbenv on PATH when it's the chosen Ruby manager (see init.zsh),
+# otherwise it silently fights asdf for ruby/gem resolution.
+[[ "${ZSH_RUBY_MANAGER:-asdf}" == "rbenv" ]] && add_path_front "$HOME/.rbenv/bin"
 add_path_back "$HOME/go/bin"
 add_path_back "$XDG_DATA_HOME/npm/bin"
 add_path_back "/opt/homebrew/opt/mysql@8.0/bin"

--- a/dot_config/zsh/src/path.zsh
+++ b/dot_config/zsh/src/path.zsh
@@ -16,7 +16,6 @@ add_path_back "$XDG_DATA_HOME/npm/bin"
 add_path_back "/opt/homebrew/opt/mysql@8.0/bin"
 add_path_back "/opt/homebrew/opt/mysql-client@8.0/bin"
 
-add_path_back "$HOME/.asdf/installs/poetry/2.2.1/bin"
 add_path_back "$HOME/tools/flutter/bin"
 
 # Flywheel specific script

--- a/dot_config/zsh/src/pet.zsh
+++ b/dot_config/zsh/src/pet.zsh
@@ -5,5 +5,5 @@ function pet_select() {
 }
 zle -N pet_select
 stty -ixon
-bindkey -M viins '^s' pet-select
-bindkey -M emacs '^s' pet-select
+bindkey -M viins '^s' pet_select
+bindkey -M emacs '^s' pet_select

--- a/dot_config/zsh/src/pet.zsh
+++ b/dot_config/zsh/src/pet.zsh
@@ -1,9 +1,9 @@
-function pet-select() {
+function pet_select() {
   BUFFER=$(pet search --query "$LBUFFER")
   CURSOR=$#BUFFER
   zle redisplay
 }
-zle -N pet-select
+zle -N pet_select
 stty -ixon
 bindkey -M viins '^s' pet-select
 bindkey -M emacs '^s' pet-select

--- a/dot_config/zsh/src/python/llm_cli/parse_response.py
+++ b/dot_config/zsh/src/python/llm_cli/parse_response.py
@@ -1,6 +1,6 @@
 import sys
 
-from python.common.execute import run_command
+from common.execute import run_command
 
 JQ_FILTER = r"""
 .[]

--- a/dot_config/zsh/src/python/sleepwatcher/set_run_on_sleep.py
+++ b/dot_config/zsh/src/python/sleepwatcher/set_run_on_sleep.py
@@ -16,7 +16,7 @@ def parse_bool(value: str) -> bool:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        prog="python -m python.sleepwatcher.set_run_on_sleep",
+        prog="python -m sleepwatcher.set_run_on_sleep",
         description="Enable or disable running tasks on sleep event.",
     )
     parser.add_argument(

--- a/dot_config/zsh/src/python/sleepwatcher/set_run_on_wake.py
+++ b/dot_config/zsh/src/python/sleepwatcher/set_run_on_wake.py
@@ -16,8 +16,8 @@ def parse_bool(value: str) -> bool:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        prog="python -m python.sleepwatcher.set_run_on_sleep",
-        description="Enable or disable running tasks on sleep event.",
+        prog="python -m sleepwatcher.set_run_on_wake",
+        description="Enable or disable running tasks on wake event.",
     )
     parser.add_argument(
         "enabled",

--- a/dot_config/zsh/src/python/sleepwatcher/should_run.py
+++ b/dot_config/zsh/src/python/sleepwatcher/should_run.py
@@ -1,6 +1,6 @@
 import sys
 
-from python.sleepwatcher.functions import sleepwatcher_db_client
+from sleepwatcher.functions import sleepwatcher_db_client
 
 
 def main() -> int:

--- a/dot_config/zsh/src/python/whisper/extract_section_from_json.py
+++ b/dot_config/zsh/src/python/whisper/extract_section_from_json.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import asdict, dataclass
 
-from python.common.execute import run_command
+from common.execute import run_command
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,8 +36,7 @@ def build_selector(from_: int | None, to: int | None) -> str:
 def iter_sections_jsonl(
     inp: str, from_: int | None, to: int | None
 ) -> Iterable[Section]:
-    """
-    Always ask jq for JSONL objects: {section_index, abs_start, abs_end, full_text}
+    """Always ask jq for JSONL objects: {section_index, abs_start, abs_end, full_text}
     Then parse into dataclass.
     """
     sel = build_selector(from_, to)

--- a/dot_config/zsh/src/zinit.zsh
+++ b/dot_config/zsh/src/zinit.zsh
@@ -25,6 +25,6 @@ autoload -Uz _zinit
 (( ${+_comps} )) && _comps[zinit]=_zinit
 
 zinit light Aloxaf/fzf-tab
-zinit light zdharma/fast-syntax-highlighting
+zinit light zdharma-continuum/fast-syntax-highlighting
 zinit light zsh-users/zsh-autosuggestions
 zinit light zsh-users/zsh-completions

--- a/dot_config/zsh/src/zsh_python_init.zsh
+++ b/dot_config/zsh/src/zsh_python_init.zsh
@@ -41,10 +41,12 @@ elif is_wsl; then
 else
     _ZSH_PYTHON="/data/data/com.termux/files/usr"
 fi
-# Only wire up paths/aliases when a venv was actually found - otherwise
-# these would silently resolve to bogus "/bin/..." paths that don't exist.
-if [[ -n "$_ZSH_PYTHON" ]]; then
-  export ZSH_PYTHON_ROOT=$_ZSH_PYTHON
+# Only wire up paths/aliases when a venv was actually found *and* the
+# interpreter inside it actually exists - a non-empty _ZSH_PYTHON isn't
+# enough (e.g. a stale poetry env path, or the hardcoded Termux prefix
+# when python was never installed there).
+if [[ -n "$_ZSH_PYTHON" && -x "$_ZSH_PYTHON/bin/python" ]]; then
+  export ZSH_PYTHON_ROOT="$_ZSH_PYTHON"
   export ZSH_PYTHON_BIN="$_ZSH_PYTHON/bin/python"
   export ZSH_PIP_BIN="$_ZSH_PYTHON/bin/pip"
 

--- a/dot_config/zsh/src/zsh_python_init.zsh
+++ b/dot_config/zsh/src/zsh_python_init.zsh
@@ -1,7 +1,10 @@
 #!/usr/bin/env zsh
 
-# core.zsh (is_macos/is_wsl, used below) is already sourced by init.zsh
-# before this file loads.
+# Don't assume init.zsh already sourced core.zsh - this file is also
+# sourced standalone (e.g. meetingbar.zsh, invoked outside any shell
+# startup chain via `zsh -c` from an AppleScript), where is_macos/is_wsl
+# would otherwise be undefined.
+[[ -f "$ZDOTDIR/src/core.zsh" ]] && source "$ZDOTDIR/src/core.zsh"
 
 function zsh_python_init() {
   local zsh_python_dir="$ZDOTDIR/src/python"

--- a/dot_config/zsh/src/zsh_python_init.zsh
+++ b/dot_config/zsh/src/zsh_python_init.zsh
@@ -21,14 +21,14 @@ function cd_zsh_python() {
 function load_zsh_python_venv_macos() {
   (
     cd "$ZDOTDIR/src/python" || exit 1
-    command "$HOME/.asdf/shims/poetry" env info -p
+    command "$HOME/.asdf/shims/poetry" env info -p 2>/dev/null
   )
 }
 
 function load_zsh_python_venv_wsl() {
   (
     cd "$ZDOTDIR/src/python" || exit 1
-    command "/home/linuxbrew/.linuxbrew/bin/poetry" env info -p
+    command "/home/linuxbrew/.linuxbrew/bin/poetry" env info -p 2>/dev/null
   )
 }
 
@@ -40,21 +40,25 @@ elif is_wsl; then
 else
     _ZSH_PYTHON="/data/data/com.termux/files/usr"
 fi
-export ZSH_PYTHON_ROOT=$_ZSH_PYTHON
-export ZSH_PYTHON_BIN="$_ZSH_PYTHON/bin/python"
-export ZSH_PIP_BIN="$_ZSH_PYTHON/bin/pip"
+# Only wire up paths/aliases when a venv was actually found - otherwise
+# these would silently resolve to bogus "/bin/..." paths that don't exist.
+if [[ -n "$_ZSH_PYTHON" ]]; then
+  export ZSH_PYTHON_ROOT=$_ZSH_PYTHON
+  export ZSH_PYTHON_BIN="$_ZSH_PYTHON/bin/python"
+  export ZSH_PIP_BIN="$_ZSH_PYTHON/bin/pip"
 
-# python cli
-export ALEMBIC_BIN="$ZSH_PYTHON_ROOT/bin/alembic"
-export LLM_BIN="$ZSH_PYTHON_ROOT/bin/llm"
-export DBT_BIN="$ZSH_PYTHON_ROOT/bin/dbt"
-export GDOWN_BIN="$ZSH_PYTHON_ROOT/bin/gdown"
-export RUFF_BIN="$ZSH_PYTHON_ROOT/bin/ruff"
+  # python cli
+  export ALEMBIC_BIN="$ZSH_PYTHON_ROOT/bin/alembic"
+  export LLM_BIN="$ZSH_PYTHON_ROOT/bin/llm"
+  export DBT_BIN="$ZSH_PYTHON_ROOT/bin/dbt"
+  export GDOWN_BIN="$ZSH_PYTHON_ROOT/bin/gdown"
+  export RUFF_BIN="$ZSH_PYTHON_ROOT/bin/ruff"
 
-alias zsh_python='$ZSH_PYTHON_BIN'
-alias zsh_pip='$ZSH_PIP_BIN'
+  alias zsh_python='$ZSH_PYTHON_BIN'
+  alias zsh_pip='$ZSH_PIP_BIN'
 
-alias llm='$LLM_BIN'
-alias alembic='$ALEMBIC_BIN'
-alias ruff='$RUFF_BIN'
-alias gdown='$GDOWN_BIN'
+  alias llm='$LLM_BIN'
+  alias alembic='$ALEMBIC_BIN'
+  alias ruff='$RUFF_BIN'
+  alias gdown='$GDOWN_BIN'
+fi

--- a/dot_config/zsh/src/zsh_python_init.zsh
+++ b/dot_config/zsh/src/zsh_python_init.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
-source "$ZDOTDIR/src/core.zsh"
+# core.zsh (is_macos/is_wsl, used below) is already sourced by init.zsh
+# before this file loads.
 
 function zsh_python_init() {
   local zsh_python_dir="$ZDOTDIR/src/python"

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -17,8 +17,8 @@ export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git
 export CONDARC="$XDG_CONFIG_HOME/conda/condarc"
 export CLAUDE_CONFIG_DIR="$XDG_CONFIG_HOME/claude"
 export DOCKER_CONFIG="$XDG_CONFIG_HOME/docker"
-export FZF_DEFAULT_COMMAND='fd --hidden --type l --type f --type d --exclude .git --exclude .cache';
-export FZF_DEFAULT_OPTS='--height=40% --cycle --info=hidden --tabstop=4 --black'
+# FZF_DEFAULT_COMMAND / FZF_DEFAULT_OPTS are defined in fzf.zsh, which loads
+# later and always wins - defining them here too just risks drift.
 export GEM_HOME="$XDG_DATA_HOME/gem"
 export GEM_SPEC_CACHE="$XDG_CACHE_HOME/gem"
 export GHCUP_USE_XDG_DIRS=1


### PR DESCRIPTION
## Summary
Fixes found while auditing the full zsh startup chain (`~/.zshenv` → `dot_zshrc` → `init.zsh` → all sourced `src/*.zsh` files, plus the sleepwatcher sleep/wake automation and its Python helpers), split by severity/topic across several commits.

### High/medium severity
- `alias.zsh`: `zshrc_edit`/`zshrc_reload` pointed at `$HOME/.zsh` / `$HOME/.zshrc`, neither of which is the real config (`$ZDOTDIR/.zshrc`) — `zshrc_reload` was silently sourcing a stale, unmanaged file instead of erroring.
- `atuin.zsh`: no `command -v atuin` guard (unlike fzf/starship/zoxide/carapace), so machines without atuin get "command not found" on every prompt and every command via the preexec/precmd hooks.
- `path.zsh`: `BUN_INSTALL` was overwritten with a bogus `.../reflex/bun` path, clobbering the correct XDG-based value from `.zshenv` and silently dropping bun's real bin dir off PATH. Also gated the unconditional `~/.rbenv/bin` PATH entry behind `ZSH_RUBY_MANAGER` so it doesn't fight asdf when rbenv isn't the chosen manager.
- `aws.zsh`: `aws_login` checked for `aws-azure-login` but actually runs `aws ... login` — mismatched dependency check from a half-finished edit.
- `darwin_post_init.zsh`: dropped a redundant, unconditional asdf-shims PATH re-prepend that ran last and could silently override an explicit `ZSH_RUBY_MANAGER=rbenv` choice made earlier in startup.
- `core.zsh` / `keybinds.zsh`: moved `bindkey -v` to run before atuin.zsh/pet.zsh install their custom `viins`/`vicmd` bindings — `bindkey -v` is known to reset those keymaps, so it needs to run first, not last.
- `zsh_python_init.zsh`: suppressed poetry stderr noise on startup, and stopped exporting `ZSH_PYTHON_BIN`/`LLM_BIN`/etc. as bogus `/bin/...` paths when no venv is found.
- `gh.zsh`: removed unreachable `rc == 2` branches — `__gh_parse_pbcopy_flag` only ever returns 0 or 10, so those "Usage: ..." error paths could never fire.

### Low severity / cleanup
- `zinit.zsh`: point `fast-syntax-highlighting` at `zdharma-continuum` (the org zinit itself is installed from), not the old, unmaintained `zdharma`.
- `functions.zsh`: `pbpaste_dump` used `sha256sum` (not on macOS by default) and `date +%s%N` (BSD `date` doesn't support `%N`, so it printed a literal "N", reducing entropy and risking same-second filename collisions) — switched to `shasum -a 256` over `/dev/urandom` output.
- `fzf.zsh`: dropped dead sourcing of `/usr/share/fzf/*.zsh` (Linux-only paths that never exist on macOS, and fully redundant with `fzf --zsh` above).
- `dot_zshenv`: removed `FZF_DEFAULT_COMMAND`/`FZF_DEFAULT_OPTS`, which `fzf.zsh` always overwrites later anyway — avoids config drift.
- `notify.zsh` + `functions.zsh`: guarded `terminal-notifier` calls with `command -v` so a missing binary fails with a clear message instead of "command not found".
- `path.zsh`: dropped a hardcoded `poetry/2.2.1` path that goes stale silently on the next asdf upgrade.
- `zsh_python_init.zsh`: dropped a redundant re-source of `core.zsh` (already sourced by `init.zsh` before this file loads).
- `darwin_pre_init.zsh`: guarded the `brew --prefix` call with `command -v brew`, suppressed its stderr, and only exports `SYS_PYTHON_ROOT`/`SYS_PYTHON_BIN`/`SYS_PIP_BIN`/aliases when the resolved interpreter actually exists (instead of unconditionally building `/bin/python3.12`-style paths when `python@3.12` isn't installed).
- `alias.zsh`: fixed `nlof`/`nzo` to point at `$ZDOTDIR/src/myscripts/...`, matching where those scripts actually live now.
- `pet.zsh`: renamed the `pet-select` widget/function to `pet_select` consistently (function, `zle -N`, and both `bindkey` calls).

### Sleepwatcher automation (sleep/wake hooks)
- `executable_sleep.zsh` / `executable_wakeup.zsh` sourced `$HOME/.zsh/darwin_pre_init.zsh` and set `PYTHONPATH` from the same pre-XDG-migration path, which no longer exists — every sleep/wake event was silently failing to load `SYS_PYTHON_BIN` and the `should_run` check, so the "skip if disabled in DB" logic never actually ran. Fixed to use `$ZDOTDIR/src/...`.
- Moved the debug log from `/tmp/sleepwatcher.log` (world-shared, periodically cleared) to `$XDG_CACHE_HOME/sleepwatcher.log`, consistent with this repo's XDG conventions.
- `~/.sleep` / `~/.wakeup` — the actual unmanaged launchd entry points referenced by `~/Library/LaunchAgents/homebrew.mxcl.sleepwatcher.plist` — had the identical dead path and were fixed directly on disk, along with their already-deployed copies under `~/.config/zsh/src/`.
- Standardized `sleepwatcher`/`llm_cli` Python modules on one consistent import convention: `should_run.py`, `llm_cli/parse_response.py`, and `whisper/extract_section_from_json.py` used a stray `from python.xxx import ...` prefix that didn't match their siblings (`set_run_on_wake.py`/`set_run_on_sleep.py`) or any real caller (`myscripts/executable_set_run_on_wake`, `executable_parse-llm-response`, `zsh_python_init()`'s `PYTHONPATH=$ZDOTDIR/src/python`) — all now use the no-prefix form. Also fixed `set_run_on_wake.py`'s `prog=`/`description` strings, which were copy-pasted from `set_run_on_sleep.py` and said "sleep" instead of "wake".

## Test plan
- [x] `zsh -n` syntax check on every modified shell file
- [x] `python3 -m py_compile` on every modified Python file
- [x] Manual diff review of every change
- [ ] `chezmoi apply` and open a fresh terminal to confirm startup is clean and `pet_select`/atuin up-arrow search still work
- [ ] Trigger an actual sleep/wake cycle to confirm `$XDG_CACHE_HOME/sleepwatcher.log` gets written and `should_run` resolves correctly